### PR TITLE
Event Storage Method Overhaul

### DIFF
--- a/Packages/com.varneon.vudon.events/Editor/UdonEventBuildPostProcessor.cs
+++ b/Packages/com.varneon.vudon.events/Editor/UdonEventBuildPostProcessor.cs
@@ -36,16 +36,15 @@ namespace Varneon.VUdon.UdonEvents.Editor
 
             foreach(FieldInfo field in fields)
             {
-                if (Attribute.IsDefined(field, typeof(UdonEventDataAttribute)))
+                if (Attribute.IsDefined(field, typeof(UdonEventAttribute)))
                 {
-                    FieldInfo dataField = fields.FirstOrDefault(f => f.Name.Equals(field.GetCustomAttribute<UdonEventDataAttribute>().EventDataFieldName));
+                    UdonEventStorage eventStorage = behaviour.GetComponent<UdonEventStorage>();
+                    
+                    int eventIndex = eventStorage.Events.FindIndex(e => e.Target.Equals(behaviour) && e.EventName.Equals(field.Name));
+                    
+                    DataList data = eventStorage.Events[eventIndex].Event.ToDataList();
 
-                    if (dataField != null)
-                    {
-                        DataList data = ((UdonEvent)field.GetValue(behaviour)).ToDataList();
-
-                        dataField.SetValue(behaviour, data);
-                    }
+                    field.SetValue(behaviour, data);
                 }
                 else if (field.FieldType.Equals(typeof(UdonEventHandler)))
                 {

--- a/Packages/com.varneon.vudon.events/Editor/UdonEventPropertyDrawer.cs
+++ b/Packages/com.varneon.vudon.events/Editor/UdonEventPropertyDrawer.cs
@@ -1,0 +1,59 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace Varneon.VUdon.UdonEvents.Editor
+{
+    [CustomPropertyDrawer(typeof(UdonEventAttribute))]
+    public class UdonEventPropertyDrawer : PropertyDrawer
+    {
+        private UdonEventStorageEditor storageEditor;
+
+        private UdonEventStorage eventStorage;
+
+        private int eventIndex;
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            return 0f;
+        }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            GetOrCreateStorageEditor(property).OnProxyInspectorGUI(eventIndex);
+        }
+
+        private UdonEventStorage GetOrAddUdonEventStorage(Component component, string eventName, string eventDisplayName)
+        {
+            if(eventStorage == null)
+            {
+                GameObject gameObject = component.gameObject;
+
+                if(!gameObject.TryGetComponent(out eventStorage))
+                {
+                    eventStorage = gameObject.AddComponent<UdonEventStorage>();
+                }
+            }
+
+            eventIndex = eventStorage.Events.FindIndex(e => e.Target.Equals(component) && e.EventName.Equals(eventName));
+
+            if(eventIndex < 0)
+            {
+                eventIndex = eventStorage.Events.Count;
+
+                eventStorage.TryBind(component, eventName, eventDisplayName);
+            }
+
+            return eventStorage;
+        }
+
+        private UdonEventStorageEditor GetOrCreateStorageEditor(SerializedProperty property)
+        {
+            if(storageEditor == null)
+            {
+                storageEditor = (UdonEventStorageEditor)UnityEditor.Editor.CreateEditor(GetOrAddUdonEventStorage((Component)property.serializedObject.targetObject, property.name, property.displayName), typeof(UdonEventStorageEditor));
+            }
+
+            return storageEditor;
+        }
+    }
+}

--- a/Packages/com.varneon.vudon.events/Editor/UdonEventPropertyDrawer.cs.meta
+++ b/Packages/com.varneon.vudon.events/Editor/UdonEventPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a9578895ba964c4b8286d7d37945599
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.varneon.vudon.events/Editor/UdonEventStorageEditor.cs
+++ b/Packages/com.varneon.vudon.events/Editor/UdonEventStorageEditor.cs
@@ -1,0 +1,62 @@
+﻿using UdonSharp;
+using UnityEditor;
+using UnityEditorInternal;
+using UnityEngine;
+
+namespace Varneon.VUdon.UdonEvents.Editor
+{
+    [CustomEditor(typeof(UdonEventStorage))]
+    public class UdonEventStorageEditor : UnityEditor.Editor
+    {
+        private UnityEventDrawer eventDrawer;
+
+        private SerializedProperty eventsProperty;
+
+        private void OnEnable()
+        {
+            UdonEventStorage eventStorage = target as UdonEventStorage;
+
+            if(eventStorage == null) { return; }
+
+            eventDrawer = new UnityEventDrawer();
+
+            eventsProperty = serializedObject.FindProperty("_events");
+
+            eventStorage.CleanUpEventsOrSelf();
+        }
+
+        public override void OnInspectorGUI() { }
+
+        public void OnProxyInspectorGUI(int eventIndex)
+        {
+            UdonEventStorage eventStorage = (UdonEventStorage)target;
+
+            serializedObject.Update();
+
+            UdonEventStorage.EventGroup eventGroup = eventStorage.Events[eventIndex];
+
+            GUIContent label = new GUIContent(eventGroup.EventDisplayName);
+
+            SerializedProperty eventGroupProperty = eventsProperty.GetArrayElementAtIndex(eventIndex);
+
+            SerializedProperty eventProperty = eventGroupProperty.FindPropertyRelative("Event");
+
+            Rect rect = EditorGUILayout.GetControlRect(GUILayout.Height(eventDrawer.GetPropertyHeight(eventProperty, label)));
+
+            using (EditorGUI.ChangeCheckScope scope = new EditorGUI.ChangeCheckScope())
+            {
+                EditorGUI.PropertyField(rect, eventProperty, label);
+
+                if(scope.changed)
+                {
+                    serializedObject.ApplyModifiedProperties();
+
+                    if (Application.isPlaying)
+                    {
+                        ((UdonSharpBehaviour)eventGroup.Target).SetProgramVariable(eventGroup.EventName, eventGroup.Event.ToDataList());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Packages/com.varneon.vudon.events/Editor/UdonEventStorageEditor.cs.meta
+++ b/Packages/com.varneon.vudon.events/Editor/UdonEventStorageEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c79c93977d3eea4ca7033344a58d69c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.varneon.vudon.events/Runtime/Scripts.meta
+++ b/Packages/com.varneon.vudon.events/Runtime/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 03a7f3738694c93468054e03571d8e11
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.varneon.vudon.events/Runtime/Scripts/UdonEventStorage.cs
+++ b/Packages/com.varneon.vudon.events/Runtime/Scripts/UdonEventStorage.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 
 namespace Varneon.VUdon.UdonEvents
 {
+    [AddComponentMenu("")]
     public class UdonEventStorage : MonoBehaviour
     {
         public List<EventGroup> Events => _events;

--- a/Packages/com.varneon.vudon.events/Runtime/Scripts/UdonEventStorage.cs
+++ b/Packages/com.varneon.vudon.events/Runtime/Scripts/UdonEventStorage.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace Varneon.VUdon.UdonEvents
+{
+    public class UdonEventStorage : MonoBehaviour
+    {
+        public List<EventGroup> Events => _events;
+
+        [SerializeField]
+        private List<EventGroup> _events = new List<EventGroup>();
+
+        [Serializable]
+        public class EventGroup
+        {
+            public Component Target;
+
+            public string EventName;
+
+            public string EventDisplayName;
+
+            public UdonEvent Event;
+
+            public EventGroup(Component target, string eventName, string eventDisplayName)
+            {
+                Target = target;
+
+                EventName = eventName;
+
+                EventDisplayName = eventDisplayName;
+            }
+        }
+
+        internal void CleanUpEventsOrSelf()
+        {
+            int removedEvents = _events.RemoveAll(e => e.Target == null);
+
+            if (removedEvents > 0)
+            {
+                Debug.LogWarning(string.Concat("[<color=#ABCDEF>UdonEventStorage</color>]: ", removedEvents, " empty events removed on '<color=#888>", name, "</color>' due to missing targets!"));
+            }
+
+            if (_events.Count == 0)
+            {
+                Debug.LogWarning(string.Concat("[<color=#ABCDEF>UdonEventStorage</color>]: Found an event storage with no events on '<color=#888>", name, "</color>'! Removing storage..."));
+
+                DestroyImmediate(this);
+            }
+        }
+
+#if UNITY_EDITOR
+        public bool TryBind(Component target, string eventName, string eventDisplayName)
+        {
+            if(_events.Any(e => e.Target.Equals(target) && e.EventName.Equals(eventName))) { return false; }
+
+            UnityEditor.Undo.RecordObject(this, "Bind UdonEventStorage");
+
+            _events.Add(new EventGroup(target, eventName, eventDisplayName));
+
+            return true;
+        }
+#endif
+    }
+}

--- a/Packages/com.varneon.vudon.events/Runtime/Scripts/UdonEventStorage.cs.meta
+++ b/Packages/com.varneon.vudon.events/Runtime/Scripts/UdonEventStorage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 624ebc3bf852c094d9aef6c22a0d6112
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.varneon.vudon.events/Runtime/Udon Programs/UdonEventHandler.cs
+++ b/Packages/com.varneon.vudon.events/Runtime/Udon Programs/UdonEventHandler.cs
@@ -11,6 +11,7 @@ namespace Varneon.VUdon.UdonEvents
     /// <summary>
     /// Singleton handler for UdonEvents
     /// </summary>
+    [AddComponentMenu("")]
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public partial class UdonEventHandler : UdonSharpBehaviour
     {

--- a/Packages/com.varneon.vudon.events/Runtime/UdonEventDataAttribute.cs
+++ b/Packages/com.varneon.vudon.events/Runtime/UdonEventDataAttribute.cs
@@ -2,13 +2,5 @@
 
 namespace Varneon.VUdon.UdonEvents
 {
-    public class UdonEventDataAttribute : PropertyAttribute
-    {
-        public readonly string EventDataFieldName;
-
-        public UdonEventDataAttribute(string eventDataFieldName)
-        {
-            EventDataFieldName = eventDataFieldName;
-        }
-    }
+    public class UdonEventAttribute : PropertyAttribute { }
 }

--- a/Packages/com.varneon.vudon.events/Runtime/UdonEventResolver.cs
+++ b/Packages/com.varneon.vudon.events/Runtime/UdonEventResolver.cs
@@ -503,6 +503,11 @@ namespace Varneon.VUdon.UdonEvents
         public void UnityEngine_FrictionJoint2D__set_maxForce() { ((FrictionJoint2D)_target).maxForce = (Single)_argument; }
         public void UnityEngine_FrictionJoint2D__set_maxTorque() { ((FrictionJoint2D)_target).maxTorque = (Single)_argument; }
         public void UnityEngine_FrictionJoint2D__set_name() { ((FrictionJoint2D)_target).name = (String)_argument; }
+        public void UnityEngine_GameObject__Find() { GameObject.Find((String)_argument); }
+        public void UnityEngine_GameObject__SetActive() { ((GameObject)_target).SetActive((Boolean)_argument); }
+        public void UnityEngine_GameObject__set_isStatic() { ((GameObject)_target).isStatic = (Boolean)_argument; }
+        public void UnityEngine_GameObject__set_layer() { ((GameObject)_target).layer = (Int32)_argument; }
+        public void UnityEngine_GameObject__set_name() { ((GameObject)_target).name = (String)_argument; }
         public void UnityEngine_HingeJoint2D__set_autoConfigureConnectedAnchor() { ((HingeJoint2D)_target).autoConfigureConnectedAnchor = (Boolean)_argument; }
         public void UnityEngine_HingeJoint2D__set_breakForce() { ((HingeJoint2D)_target).breakForce = (Single)_argument; }
         public void UnityEngine_HingeJoint2D__set_breakTorque() { ((HingeJoint2D)_target).breakTorque = (Single)_argument; }

--- a/Packages/com.varneon.vudon.events/Runtime/UdonEventResolver.cs
+++ b/Packages/com.varneon.vudon.events/Runtime/UdonEventResolver.cs
@@ -19,9 +19,11 @@ namespace Varneon.VUdon.UdonEvents
 {
     public partial class UdonEventHandler : UdonSharpBehaviour
     {
+        public void VRC_Udon_UdonBehaviour__RequestSerialization() { ((UdonBehaviour)_target).RequestSerialization(); }
+        public void VRC_Udon_UdonBehaviour__SendCustomEvent() { ((UdonBehaviour)_target).SendCustomEvent((String)_argument); }
+        public void VRC_Udon_UdonBehaviour__set_DisableInteractive() { ((UdonBehaviour)_target).DisableInteractive = (Boolean)_argument; }
+        public void VRC_Udon_UdonBehaviour__set_InteractionText() { ((UdonBehaviour)_target).InteractionText = (String)_argument; }
         public void VRC_Udon_UdonBehaviour__set_enabled() { ((UdonBehaviour)_target).enabled = (Boolean)_argument; }
-        public void VRC_Udon_UdonBehaviour__SendCustomEvent() { ((UdonBehaviour)_target).SendCustomEvent((string)_argument); }
-
         public void Cinemachine_CinemachineDollyCart__set_enabled() { ((CinemachineDollyCart)_target).enabled = (Boolean)_argument; }
         public void Cinemachine_CinemachineDollyCart__set_m_Path() { ((CinemachineDollyCart)_target).m_Path = (CinemachinePathBase)_argument; }
         public void Cinemachine_CinemachineDollyCart__set_m_Position() { ((CinemachineDollyCart)_target).m_Position = (Single)_argument; }

--- a/Packages/com.varneon.vudon.events/package.json
+++ b/Packages/com.varneon.vudon.events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.varneon.vudon.events",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "UnityEvents for UdonSharp",
   "displayName": "VUdon - Events",
   "author": {

--- a/README.md
+++ b/README.md
@@ -56,10 +56,6 @@ namespace Varneon.VUdon.UdonEvents
 
 # Known issues
 
-> [`#1 UdonSharp throws errors about UdonEvent field not being compatible with serializer`](https://github.com/Varneon/VUdon-Events/issues/1)
->
->![image](https://github.com/Varneon/VUdon-Events/assets/26690821/c473468e-5b8d-4061-a3c5-5a4e0a369bfb)
-
 > [`#2 There is no indication of whether a call was successfully invoked or not`](https://github.com/Varneon/VUdon-Events/issues/2)
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -26,24 +26,14 @@ namespace Varneon.VUdon.UdonEvents
         [SerializeField, HideInInspector]
         private UdonEventHandler udonEventHandler;
 
-        // Declare a serialized hidden DataList field for each UdonEvent
-        [SerializeField, HideInInspector]
+        // Declare a serialized DataList field for each UdonEvent
+        [SerializeField, UdonEvent]
         private DataList onPlayerTriggerEntered;
 
-        // Each element on the DataList is an individual persistent call from the UnityEvent
-        [SerializeField, HideInInspector]
+        // Add UdonEventAttribute to the DataList fields for overriding
+        // the property drawer with the UdonEvent drawer
+        [SerializeField, UdonEvent]
         private DataList onPlayerTriggerExited;
-
-
-        // Declare UdonEvent fields for each UdonEvent you want to expose in the inspector
-        [UdonEventData(nameof(onPlayerTriggerEntered))]
-        public UdonEvent OnPlayerTriggerEntered;
-
-        // Add UdonEventDataAttribute to the UdonEvent fields for defining
-        // the DataList field for storing the persistent calls for runtime
-        [UdonEventData(nameof(onPlayerTriggerExited))]
-        public UdonEvent OnPlayerTriggerExited;
-
 
         public override void OnPlayerTriggerEnter(VRCPlayerApi player)
         {


### PR DESCRIPTION
Closes #1 

# Changes
* [`UdonEvents`](https://github.com/Varneon/VUdon-Events/blob/event-storages/Packages/com.varneon.vudon.events/Runtime/UdonEvent.cs) are now stored in [`UdonEventStorages`](https://github.com/Varneon/VUdon-Events/blob/event-storages/Packages/com.varneon.vudon.events/Runtime/Scripts/UdonEventStorage.cs) instead of the **UdonSharpBehaviours** in order to prevent UdonSharp getting mad (#1)
* Added several missing setters and methods (7bf52b3e465246c3e536c45dc3036c3195c159fe, 9420535ae192af040d262f43f443e0956af908d5)
> :warning: [`UdonEvent`](https://github.com/Varneon/VUdon-Events/blob/event-storages/Packages/com.varneon.vudon.events/Runtime/UdonEvent.cs) fields don't get declared in the **UdonSharpBehaviour** anymore.
> :warning: [`UdonEventAttribute`](https://github.com/Varneon/VUdon-Events/blob/event-storages/Packages/com.varneon.vudon.events/Runtime/UdonEventDataAttribute.cs) now has to be attached to the `DataList` field on the **UdonSharpBehaviour** without a string parameter.